### PR TITLE
Add Custom Attributes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 /**
  * We.js form feature, see plugin.js file
  */
+
+var _ = require('lodash');
 module.exports = function(we) {
   return {
     // loaded forms
@@ -49,7 +51,7 @@ module.exports = function(we) {
 
     renderField: function renderField(attrName, attr, attributes, values, errors, theme, locals, formId, modelName, isModel) {
       var fieldAttrs= '', type;
-
+      var formFieldAttributes = attr.formFieldAttributes;
       if (isModel) {
         type = we.form.getFieldType(attr);
       } else {
@@ -62,7 +64,14 @@ module.exports = function(we) {
       if (!value) value = attr.defaultValue;
       if (!value) value = '';
       // get required field attr
-      if (attr.allowNull === false) fieldAttrs += ' required="required"';
+      if (attr.allowNull === false) fieldAttrs += ' required=required';
+      if (_.isObject(formFieldAttributes)) {
+        _.forOwn(formFieldAttributes, function (attrValue, attrName) {
+          if (!attrName || !attrValue) return;
+
+          fieldAttrs += ' ' + attrName + '=' + attrValue + '';
+        });
+      }
 
       var fieldOptions = (attr.formFieldOptions || {});
       // use type attr


### PR DESCRIPTION
Now we can add custom attributes to the form adding simple `formFieldAttribute`

``` js
      message: {
        type: we.db.Sequelize.TEXT,
        formFieldType: 'textarea',
        formFieldAttributes: {
          rows: 6
        },
        allowNull: false
      }
```
